### PR TITLE
应用route.php配置项无法自动加载修复

### DIFF
--- a/thinkphp/library/think/app.php
+++ b/thinkphp/library/think/app.php
@@ -37,6 +37,8 @@ class App
                 Config::load($file, $file);
             }
         }
+        // 合并扩展配置文件配置项
+        $config = Config::get();
 
         // 日志初始化
         Log::init($config['log']);


### PR DESCRIPTION
扩展配置文件内容没有合并到self::dispatch($config)的$config参数中，导致route.php中的路由配置无法注册到Route类中。