### PR TITLE
修复不能使用memcache

### DIFF
--- a/thinkphp/library/think/cache/driver/memcache.php
+++ b/thinkphp/library/think/cache/driver/memcache.php
@@ -24,7 +24,7 @@ class Memcache
         'host'       => '127.0.0.1',
         'port'       => 11211,
         'expire'     => 0,
-        'timeout'    => false,
+        'timeout'    => 1,
         'persistent' => false,
         'length'     => 0,
     ];


### PR DESCRIPTION
![qq 20151231135244](https://cloud.githubusercontent.com/assets/16282406/12062284/4268e040-afd4-11e5-88e2-9092b0558311.png)
默认的false 不能使用 看了文档发现是值类型现在用的1 默认也是1