### PR TITLE
当开启多语言模块时，定义的语言包中，语言的键为纯数字时，在加载语言文件时使用array_merge合并多个语言包时，会自动将数字的键…

### DIFF
--- a/thinkphp/library/think/Lang.php
+++ b/thinkphp/library/think/Lang.php
@@ -43,7 +43,7 @@ class Lang
             self::$lang[$range] = [];
         }
         if (is_array($name)) {
-            return self::$lang[$range] = array_merge(self::$lang[$range], array_change_key_case($name));
+            return self::$lang[$range] = array_change_key_case($name) + self::$lang[$range];
         } else {
             return self::$lang[$range][strtolower($name)] = $value;
         }
@@ -70,10 +70,10 @@ class Lang
             // 记录加载信息
             APP_DEBUG && Log::record('[ LANG ] ' . $file, 'info');
             $_lang = is_file($_file) ? include $_file : [];
-            $lang  = array_merge($lang, array_change_key_case($_lang));
+            $lang  = array_change_key_case($_lang) + $lang;
         }
         if (!empty($lang)) {
-            self::$lang[$range] = array_merge(self::$lang[$range], $lang);
+            self::$lang[$range] = $lang + self::$lang[$range];
         }
         return self::$lang[$range];
     }


### PR DESCRIPTION
当开启多语言模块时，在定义的语言包中，语言的键为纯数字时，在加载语言文件时使用array_merge合并多个语言包时，array_merge方法会自动将自定义的数字键替换为默认索引值键的bug