### PR TITLE
添加日志记录，以及添加异常忽略支持

### DIFF
--- a/thinkphp/convention.php
+++ b/thinkphp/convention.php
@@ -105,6 +105,9 @@ return [
 
     // 异常页面的模板文件
     'exception_tmpl'        => THINK_PATH . 'tpl' . DS . 'think_exception.tpl',
+    // 异常处理忽略的错误类型，支持PHP所有的错误级别常量，多个级别可以用|运算法
+    // 参考：http://php.net/manual/en/errorfunc.constants.php
+    'exception_ignore_type' => 0,
     // 错误显示信息,非调试模式有效
     'error_message'         => '页面错误！请稍后再试～',
     // 错误定向页面

--- a/thinkphp/library/think/Error.php
+++ b/thinkphp/library/think/Error.php
@@ -93,7 +93,7 @@ class Error
     {
         if ($errno & Config::get('exception_ignore_type')) {
             // 忽略的异常记录到日志
-            Log::record("[{$data['code']}]{$data['message']}[{$data['file']}:{$data['line']}]", 'notic');
+            Log::record("[{$errno}]{$errstr}[{$errfile}:{$errline}]", 'notic');
         } else {
             // 将错误信息托管至 think\exception\ErrorException
             throw new ErrorException($errno, $errstr, $errfile, $errline);

--- a/thinkphp/library/think/Exception.php
+++ b/thinkphp/library/think/Exception.php
@@ -15,7 +15,7 @@ namespace think;
  * ThinkPHP核心异常类
  * 所有系统异常必须继承该类
  */
-class Exception extends \Exception 
+class Exception extends \Exception
 {
     /**
      * 系统异常后发送给客户端的HTTP Status
@@ -32,7 +32,7 @@ class Exception extends \Exception
     /**
      * 设置异常额外的Debug数据
      * 数据将会显示为下面的格式
-     * 
+     *
      * Exception Data
      * --------------------------------------------------
      * Label 1
@@ -41,11 +41,11 @@ class Exception extends \Exception
      * Label 2
      *   key1      value1
      *   key2      value2
-     * 
+     *
      * @param string $label 数据分类，用于异常页面显示
      * @param Array  $data  需要显示的数据，必须为关联数组
      */
-    final protected function setData($label, Array $data)
+    final protected function setData($label, array $data)
     {
         $this->data[$label] = $data;
     }

--- a/thinkphp/library/think/log/driver/File.php
+++ b/thinkphp/library/think/log/driver/File.php
@@ -71,7 +71,8 @@ class File
 
         $server = isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '0.0.0.0';
         $remote = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
-        error_log("[{$now}] {$server} {$remote} {$_SERVER['REQUEST_URI']}\r\n{$info}\r\n", 3, $destination);
+        $uri    = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
+        error_log("[{$now}] {$server} {$remote} {$uri}\r\n{$info}\r\n", 3, $destination);
     }
 
 }

--- a/thinkphp/library/think/log/driver/File.php
+++ b/thinkphp/library/think/log/driver/File.php
@@ -68,7 +68,10 @@ class File
         foreach ($log as $line) {
             $info .= '[' . $line['type'] . '] ' . $line['msg'] . "\r\n";
         }
-        error_log("[{$now}] {$_SERVER['SERVER_ADDR']} {$_SERVER['REMOTE_ADDR']} {$_SERVER['REQUEST_URI']}\r\n{$info}\r\n", 3, $destination);
+
+        $server = isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '0.0.0.0';
+        $remote = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
+        error_log("[{$now}] {$server} {$remote} {$_SERVER['REQUEST_URI']}\r\n{$info}\r\n", 3, $destination);
     }
 
 }


### PR DESCRIPTION
异常忽略支持忽略指定的异常类型，被忽略的异常仅仅记录到日志，不会中断程序执行
忽略的异常类型支持PHP的所有错误级别，多个级别支持 | 运算符
参考：http://php.net/manual/en/errorfunc.constants.php