### PR TITLE
修正notice 的拼写错误

### DIFF
--- a/thinkphp/library/think/Error.php
+++ b/thinkphp/library/think/Error.php
@@ -93,7 +93,7 @@ class Error
     {
         if ($errno & Config::get('exception_ignore_type')) {
             // 忽略的异常记录到日志
-            Log::record("[{$errno}]{$errstr}[{$errfile}:{$errline}]", 'notic');
+            Log::record("[{$errno}]{$errstr}[{$errfile}:{$errline}]", 'notice');
         } else {
             // 将错误信息托管至 think\exception\ErrorException
             throw new ErrorException($errno, $errstr, $errfile, $errline, $errcontext);
@@ -266,8 +266,6 @@ class Error
             'LANG_SET'         => defined('LANG_SET') ? LANG_SET : 'undefined',
             'EXT'              => defined('EXT') ? EXT : 'undefined',
             'DS'               => defined('DS') ? DS : 'undefined',
-            '__INFO__'         => defined('__INFO__') ? __INFO__ : 'undefined',
-            '__EXT__'          => defined('__EXT__') ? __EXT__ : 'undefined',
             '__INFO__'         => defined('__INFO__') ? __INFO__ : 'undefined',
             '__EXT__'          => defined('__EXT__') ? __EXT__ : 'undefined',
         ];

--- a/thinkphp/library/think/Loader.php
+++ b/thinkphp/library/think/Loader.php
@@ -71,7 +71,7 @@ class Loader
                 APP_DEBUG && self::$load[] = $filename;
                 include $filename;
             } else {
-                Log::record('autoloader error : ' . $filename, 'notic');
+                Log::record('autoloader error : ' . $filename, 'notice');
             }
         }
     }
@@ -294,7 +294,7 @@ class Loader
             if (class_exists($class)) {
                 $model = new $class($name);
             } else {
-                Log::record('实例化不存在的类：' . $class, 'notic');
+                Log::record('实例化不存在的类：' . $class, 'notice');
                 $model = new Model($name);
             }
         }

--- a/thinkphp/library/think/Log.php
+++ b/thinkphp/library/think/Log.php
@@ -13,17 +13,17 @@ namespace think;
 
 class Log
 {
-    const LOG   = 'log';
-    const ERROR = 'error';
-    const INFO  = 'info';
-    const SQL   = 'sql';
-    const NOTIC = 'notic';
-    const ALERT = 'alert';
+    const LOG    = 'log';
+    const ERROR  = 'error';
+    const INFO   = 'info';
+    const SQL    = 'sql';
+    const NOTICE = 'notice';
+    const ALERT  = 'alert';
 
     // 日志信息
     protected static $log = [];
     // 日志类型
-    protected static $type = ['log', 'error', 'info', 'sql', 'notic', 'alert'];
+    protected static $type = ['log', 'error', 'info', 'sql', 'notice', 'alert'];
     // 日志写入驱动
     protected static $driver = null;
     // 通知发送驱动
@@ -37,7 +37,7 @@ class Log
         unset($config['type']);
         self::$driver = new $class($config);
         // 记录初始化信息
-        APP_DEBUG && Log::record('[ LOG ] INIT ' . $type . ':' . var_export($config, true), 'info');
+        APP_DEBUG && Log::record('[ LOG ] INIT ' . $type . ': ' . var_export($config, true), 'info');
     }
 
     // 通知初始化
@@ -48,7 +48,7 @@ class Log
         unset($config['type']);
         self::$alarm = new $class($config['alarm']);
         // 记录初始化信息
-        APP_DEBUG && Log::record('[ CACHE ] ALARM ' . $type . ':' . var_export($config, true), 'info');
+        APP_DEBUG && Log::record('[ CACHE ] ALARM ' . $type . ': ' . var_export($config, true), 'info');
     }
 
     /**
@@ -111,6 +111,7 @@ class Log
 
     /**
      * 发送预警通知
+     * @param mixed $msg 调试信息
      * @return void
      */
     public static function send($msg)

--- a/thinkphp/library/think/log/driver/Socket.php
+++ b/thinkphp/library/think/log/driver/Socket.php
@@ -94,7 +94,7 @@ class Socket
         ];
 
         foreach ($logs as &$log) {
-            if (in_array($log['type'], ['sql', 'notic', 'debug', 'info'])) {
+            if (in_array($log['type'], ['sql', 'notice', 'debug', 'info'])) {
                 $log['type'] = 'log';
             }
         }

--- a/thinkphp/library/think/log/driver/Trace.php
+++ b/thinkphp/library/think/log/driver/Trace.php
@@ -15,7 +15,7 @@ namespace think\log\driver;
  */
 class Trace
 {
-    protected $tabs   = ['base' => '基本', 'file' => '文件', 'info' => '流程', 'notic|error' => '错误', 'sql' => 'SQL', 'debug|log' => '调试'];
+    protected $tabs   = ['base' => '基本', 'file' => '文件', 'info' => '流程', 'notice|error' => '错误', 'sql' => 'SQL', 'debug|log' => '调试'];
     protected $config = [
         'trace_file' => '',
     ];

--- a/thinkphp/tests/thinkphp/library/think/log/driver/.gitignore
+++ b/thinkphp/tests/thinkphp/library/think/log/driver/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/thinkphp/tests/thinkphp/library/think/log/driver/fileTest.php
+++ b/thinkphp/tests/thinkphp/library/think/log/driver/fileTest.php
@@ -1,0 +1,34 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2006~2016 http://thinkphp.cn All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+
+/**
+ * Test File Log
+ */
+namespace tests\thinkphp\library\think\log\driver;
+
+use think\Log;
+
+class fileTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        Log::init(['type' => 'file']);
+    }
+
+    public function testRecord()
+    {
+        $record_msg = 'record';
+        Log::record($record_msg, 'notice');
+        $logs = Log::getLog();
+
+        $this->assertNotFalse(array_search(['type' => 'notice', 'msg' => $record_msg], $logs));
+    }
+}


### PR DESCRIPTION
1）修正notice 的拼写错误
2）英文的":"后面加了个空格
3）补全Log::send() 注释
4）删除Error.php 里重复的 key
5）添加 File Log 测试用例