### PR TITLE
修复部署模式下抛异常时的一个E_NOTICE错误

### DIFF
--- a/thinkphp/library/think/Error.php
+++ b/thinkphp/library/think/Error.php
@@ -65,16 +65,18 @@ class Error
                     'ThinkPHP Constants'    => self::getTPConst(),
                 ],
             ];
+            $err_msg = "[{$data['code']}]{$data['message']}[{$data['file']}:{$data['line']}]";
         } else {
             // 部署模式仅显示 Code 和 Message
             $data = [
                 'code'    => $exception->getCode(),
                 'message' => Config::get('show_error_msg') ? $exception->getMessage() : Config::get('error_message'),
             ];
+            $err_msg = "[{$data['code']}]{$data['message']}";
         }
 
         // 记录异常日志
-        Log::record("[{$data['code']}]{$data['message']}[{$data['file']}:{$data['line']}]", 'error');
+        Log::record($err_msg, 'error');
         // 输出错误信息
         self::output($exception, $data);
         // 禁止往下传播已处理过的异常


### PR DESCRIPTION
因为部署模式下没有设置 $data['file] 和 $data['line'] 这两个值，会报E_NOTICE错误。