### PR TITLE
解决非windows环境下getModelName获取不到basename的bug

### DIFF
--- a/thinkphp/library/think/Model.php
+++ b/thinkphp/library/think/Model.php
@@ -1198,7 +1198,8 @@ class Model
     public function getModelName()
     {
         if (empty($this->name)) {
-            $this->name = basename(get_class($this));
+            // 解决非windows环境下获取不到basename的bug(xiaobo.sun modify 20160215)
+            $this->name = basename(str_replace('\\', '/', get_class($this)));
         }
         return $this->name;
     }


### PR DESCRIPTION
basename：在 Windows 中，斜线（/）和反斜线（\）都可以用作目录分隔符。在其它环境下是斜线（/）。