### PR TITLE
修改setInc,setDec方法执行错误的bug

### DIFF
--- a/thinkphp/library/think/Model.php
+++ b/thinkphp/library/think/Model.php
@@ -706,6 +706,7 @@ class Model
                 $step = '-' . $step;
             }
         }
+        $this->duplicate = [];
         return $this->setField($field, ['exp', $field . '+' . $step]);
     }
 
@@ -735,6 +736,7 @@ class Model
                 $step = '-' . $step;
             }
         }
+        $this->duplicate = [];
         return $this->setField($field, ['exp', $field . '-' . $step]);
     }
 


### PR DESCRIPTION
在调用setInc,setDec方法时处理$this->duplicate = [];为空。否则在209行的
// 存在数据副本
$data = array_diff_assoc($data, $this->duplicate);
验证不通过