### PR TITLE
修正当define("CONTROLLER_LAYER","")时，找不到对应的CLASS的BUG

### DIFF
--- a/thinkphp/library/think/Loader.php
+++ b/thinkphp/library/think/Loader.php
@@ -413,6 +413,6 @@ class Loader
         $array = explode('\\', $name);
         $class = self::parseName(array_pop($array), 1);
         $path  = $array ? implode('\\', $array) . '\\' : '';
-        return APP_NAMESPACE . '\\' . (APP_MULTI_MODULE ? $module . '\\' : '') . $layer . '\\' . $path . $class;
+        return APP_NAMESPACE . '\\' . (APP_MULTI_MODULE ? $module . '\\' : '') . (empty($layer) ? '' : $layer . '\\') . $path . $class;
     }
 }


### PR DESCRIPTION
当自定义CONTROLLER_LAYER常量为空的时候，会报 class [ app\admin\\shop\Shop ] not exists 的错误。中间有两个双斜杠