### PR TITLE
1.增加验证规则的字段名对通配符*的支持，字段名可使用name.*，goods.*.price这样的形式进行多项验证或填充；

### DIFF
--- a/thinkphp/tests/thinkphp/library/think/modelTest.php
+++ b/thinkphp/tests/thinkphp/library/think/modelTest.php
@@ -1,0 +1,79 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2006~2016 http://thinkphp.cn All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+
+/**
+ * 模板测试
+ * @author    Haotong Lin <lofanmi@gmail.com>
+ */
+
+namespace tests\thinkphp\library\think;
+
+use think\Model;
+
+class templateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidate()
+    {
+        $model = new Model();
+        $data = [
+            'name' => ['a' => 'a', 'b' => 'b'],
+            'goods' => [
+                0 => [
+                    0 => [
+                        'item' => 'item',
+                        'price' => '100',
+                    ],
+                    1 => [
+                        'item' => 'item2',
+                        'price' => '100',
+                    ]
+                ]
+            ]
+        ];
+
+        $validate = [
+            'name.*' => function($value, $data) {return empty($value) ? 'not empty' : true;},
+            'goods.*.*.price' => ['/\d+/', 'mast int'],
+        ];
+        $result = $model->validate($validate)->create($data);
+        $this->assertEquals('', $model->getError());
+    }
+
+    public function testFill()
+    {
+        $model = new Model();
+        $data = [
+            'name' => ['a' => 'a', 'b' => 'b'],
+            'goods' => [
+                0 => [
+                    0 => [
+                        'item' => 'item',
+                        'price' => '',
+                    ],
+                    1 => [
+                        'item' => 'item2',
+                        'price' => '',
+                    ]
+                ]
+            ]
+        ];
+
+        $auto = [
+            'name.*' => 'name',
+            'goods.*.*.price' => 100,
+        ];
+        $result = $model->auto($auto)->create($data);
+        $data['name']['a'] = $data['name']['b'] = 'name';
+        $data['goods'][0][0]['price'] = 100;
+        $data['goods'][0][1]['price'] = 100;
+        $this->assertEquals($data, $result);
+    }
+}

--- a/thinkphp/tests/thinkphp/library/think/templateTest.php
+++ b/thinkphp/tests/thinkphp/library/think/templateTest.php
@@ -257,7 +257,7 @@ EOF;
         $_GET['action']         = 'action';
         $_POST['action']        = 'action';
         $_COOKIE['name']        = 'name';
-        \think\Session::set('action', ['name' => 'name']);
+        $_SESSION['action']     = ['name' => 'name'];
         define('SITE_NAME', 'site_name');
 
         $content = <<<EOF


### PR DESCRIPTION
2.改进验证规则对正则表达式的处理。