### PR TITLE
非文件缓存类时读取总配置文件下相应缓存配置

### DIFF
--- a/thinkphp/library/think/Cache.php
+++ b/thinkphp/library/think/Cache.php
@@ -37,6 +37,8 @@ class Cache
             $type  = !empty($options['type']) ? $options['type'] : 'File';
             $class = (!empty($options['namespace']) ? $options['namespace'] : '\\think\\cache\\driver\\') . ucwords($type);
             unset($options['type']);
+            // 读取配置文件中相应类型下的配置信息 by xiaobo.sun@qq.com
+            $options = array_merge($options, (array)\think\Config::get($type));
             self::$instance[$md5] = new $class($options);
             // 记录初始化信息
             APP_DEBUG && Log::record('[ CACHE ] INIT ' . $type . ':' . var_export($options, true), 'info');


### PR DESCRIPTION
增加在初始化Cache缓存时，如果选择非文件缓存类时可以读取总配置文件下相应缓存类型为key的配置项数组