### PR TITLE
修复undefined index:extra

### DIFF
--- a/thinkphp/library/think/db/driver/Mysql.php
+++ b/thinkphp/library/think/db/driver/Mysql.php
@@ -130,8 +130,10 @@ class Mysql extends Driver
         $pdo    = $this->linkID->query("EXPLAIN " . $sql);
         $result = $pdo->fetch(\PDO::FETCH_ASSOC);
         $result = array_change_key_case($result);
-        if (strpos($result['extra'], 'filesort') || strpos($result['extra'], 'temporary')) {
-            Log::record('SQL:' . $this->queryStr . '[' . $result['extra'] . ']', 'warn');
+        if (isset($result['extra'])) {
+            if (strpos($result['extra'], 'filesort') || strpos($result['extra'], 'temporary')) {
+                Log::record('SQL:' . $this->queryStr . '[' . $result['extra'] . ']', 'warn');
+            }
         }
         return $result;
     }


### PR DESCRIPTION
在使用阿里云DRDS时遇到extra这个键没有定义的情况