### PR TITLE
多维数组的点语法支持数字键值

### DIFF
--- a/thinkphp/library/think/Template.php
+++ b/thinkphp/library/think/Template.php
@@ -793,7 +793,7 @@ class Template
     public function parseVar(&$varStr)
     {
         $varStr = trim($varStr);
-        if (preg_match_all('/\$[a-zA-Z_](?>\w*)(?:[:\.][a-zA-Z_](?>\w*))+/', $varStr, $matches, PREG_OFFSET_CAPTURE)) {
+        if (preg_match_all('/\$[a-zA-Z_](?>\w*)(?:[:\.][0-9a-zA-Z_](?>\w*))+/', $varStr, $matches, PREG_OFFSET_CAPTURE)) {
             static $_varParseList = [];
             while ($matches[0]) {
                 $match = array_pop($matches[0]);


### PR DESCRIPTION
多维数组的点语法支持数字键值，如：`{$arr.0}`、`{$arr.0.id}`、`{$arr.1key.2key}`。

但这有个冲突的地方，因为点语法同时也要支持对象，而对象中变量名不以数字开头。看你们如何解决了