### PR TITLE
修复内置模版引擎无法自动获取静态缓存的问题

### DIFF
--- a/thinkphp/library/think/Template.php
+++ b/thinkphp/library/think/Template.php
@@ -169,6 +169,14 @@ class Template
         if ($config) {
             $this->config($config);
         }
+        if (!empty($this->config['cache_id']) && $this->config['display_cache']) {
+            // 读取渲染缓存
+            $cacheContent = Cache::get($this->config['cache_id']);
+            if ($cacheContent !== false) {
+                echo $cacheContent;
+                return;
+            }
+        }
         $template = $this->parseTemplateFile($template);
         if ($template) {
             $cacheFile = $this->config['cache_path'] . $this->config['cache_prefix'] . md5($template) . $this->config['cache_suffix'];

--- a/thinkphp/tests/thinkphp/library/think/templateTest.php
+++ b/thinkphp/tests/thinkphp/library/think/templateTest.php
@@ -319,8 +319,10 @@ EOF;
         $template = new Template();
         $template->assign('name', 'name');
         $config = [
-            'strip_space' => true,
-            'view_path'   => dirname(__FILE__) . '/',
+            'strip_space'  => true,
+            'view_path'    => dirname(__FILE__) . '/',
+            'cache_id'     => '__CACHE_ID__',
+            'display_cache'=> true
         ];
         $data = ['name' => 'value'];
         $template->layout('layout')->display('display', $data, $config);
@@ -400,5 +402,13 @@ EOF;
         $data     = ['a' => 'a', 'b' => 'b'];
         $template->assign($data);
         $this->assertEquals($data, $template->get());
+    }
+
+    public function testIsCache()
+    {
+        $template = new Template(['cache_id' => '__CACHE_ID__','display_cache' => true]);
+        $this->assertTrue(!$template->isCache('__CACHE_ID__'));
+        $template->display_cache = false;
+        $this->assertTrue(!$template->isCache('__CACHE_ID__'));
     }
 }


### PR DESCRIPTION
在设置cache_id和display_cache为true之后，虽然缓存了静态内容，但渲染的时候没有对静态缓存的有效性作判断，直接又进行下一步编译去了。