### PR TITLE
添加：忽略框架目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 composer.lock
 *.log
+thinkphp


### PR DESCRIPTION
既然框架与应用仓库独立开来，那么应用仓库还是忽略框架目录比较好