### PR TITLE
change think

### DIFF
--- a/think
+++ b/think
@@ -16,4 +16,4 @@ namespace think;
 require __DIR__ . '/vendor/autoload.php';
 
 // 应用初始化
-(new App())->console->run();
+App::getInstance()->console->run();

--- a/think
+++ b/think
@@ -16,4 +16,4 @@ namespace think;
 require __DIR__ . '/vendor/autoload.php';
 
 // 应用初始化
-App::getInstance()->console->run();
+App::pull("console")->run();


### PR DESCRIPTION
修复容器不同的bug

如果其他扩展包中引用了TP核心的容器。由于如下代码会重新创建一个容器，导致其他包中获取的容器和当前框架的容器不是同一个对象。
```
(new App())->console->run();
```