### PR TITLE
更新运行环境要求及README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ThinkPHP 6.0
 ===============
 
-> 运行环境要求PHP7.1+，兼容PHP8.0。
+> 运行环境要求PHP7.2+，兼容PHP8.1
 
 [官方应用服务市场](https://market.topthink.com) | [`ThinkAPI`——官方统一API服务](https://docs.topthink.com/think-api)
 
@@ -47,7 +47,7 @@ ThinkPHP遵循Apache2开源协议发布，并提供免费使用。
 
 本项目包含的第三方源码和二进制文件之版权信息另行标注。
 
-版权所有Copyright © 2006-2020 by ThinkPHP (http://thinkphp.cn)
+版权所有Copyright © 2006-2021 by ThinkPHP (http://thinkphp.cn)
 
 All rights reserved。
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }        
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.5",
         "topthink/framework": "^6.0.0",
         "topthink/think-orm": "^2.0"
     },


### PR DESCRIPTION
核心框架top-think/framework从v6.0.9开始，PHP运行环境要求已经提升到7.2.5+ ,  因此，更新应用仓库的运行环境要求及README说明