### PR TITLE
修正创建项目后变成 6.1 版本

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "topthink/framework": "^6.0.0",
+        "topthink/framework": "6.0.*",
         "topthink/think-orm": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
目前 `composer.json` 中指定的 `topthink/framework` 版本是 `^6.0.0`，导致想安装 ThinkPHP 6.0，安装后变成 6.1