### PR TITLE
session配置添加path参数使session使用不同驱动时默认行为一致

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -16,4 +16,6 @@ return [
     'expire'         => 1440,
     // 前缀
     'prefix'         => '',
+    // 路径 当type使用file的时候有效，设置则session跨应用，留空则只在当前应用有效
+    'path' => app()->getRootPath() . 'runtime',
 ];

--- a/config/session.php
+++ b/config/session.php
@@ -17,5 +17,5 @@ return [
     // 前缀
     'prefix'         => '',
     // 路径 当type使用file的时候有效，设置则session跨应用，留空则只在当前应用有效
-    'path' => app()->getRootPath() . 'runtime',
+    'path' => app()->getRootPath() . 'runtime/session',
 ];


### PR DESCRIPTION
这问题困扰了很多人。文档里面说：如果不希望共享会话数据，可以给每个应用设置不同的前缀prefix，但file又可以通过path参数。
导致结果默认是redis跨，file不跨造成混乱。